### PR TITLE
Include rpc/types.h for Mac OSX compiles.

### DIFF
--- a/kd.c
+++ b/kd.c
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <sys/time.h>
 #include <sys/resource.h>
+#include <rpc/types.h>
 #include <rpc/xdr.h>
 #include <assert.h>
 #include "kd.h"


### PR DESCRIPTION
Attempt to fix Mac OSX compiles.  This needs testing.